### PR TITLE
Fix syntax that was uncaught in merge conflict

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -179,6 +179,8 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 if [[ "${BUILDKITE_PLUGIN_DOCKER_MOUNT_SSH_AGENT:-$mount_ssh_agent}" =~ ^(true|on|1)$ ]] ; then
   # shellcheck source=lib/pd-ssh.bash
   . "$DIR/../lib/pd-ssh.bash"
+fi
+
 # Support docker run --userns
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_USERNS:-}" ]]; then
   args+=("--userns" "${BUILDKITE_PLUGIN_DOCKER_USERNS:-}")


### PR DESCRIPTION
Uncaught in PR #2 merge

```
mbp:~/sandbox/docker-buildkite-plugin [fix-merge-conflict u= 7d7e5b2]
$ shellcheck hooks/command

In hooks/command line 181:
  . "$DIR/../lib/pd-ssh.bash"
    ^-----------------------^ SC1091: Not following: lib/pd-ssh.bash was not specified as input (see shellcheck -x).


In hooks/command line 241:
. "$DIR/../lib/pd-secrets.bash"
  ^---------------------------^ SC1091: Not following: lib/pd-secrets.bash was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: lib/pd-secrets.bas...
mbp:~/sandbox/docker-buildkite-plugin [fix-merge-conflict u= 7d7e5b2]
$
```